### PR TITLE
Add Custom result type and Rely Matcher Extension

### DIFF
--- a/lib/Parser.re
+++ b/lib/Parser.re
@@ -1,6 +1,6 @@
 type result('a) =
   | Success('a, string)
-  | Failure(string)
+  | Failure(string);
 
 type t('a) =
   | Parser(string => result('a));
@@ -29,12 +29,12 @@ let pchar = char => {
 
 let andThen = (p1, p2) => {
   let fn = input =>
-    switch (input |> run(p1)) {
+    switch (run(p1, input)) {
     | Failure(msg) => Failure(msg)
-    | Success(v1, remaining) =>
+    | Success(val1, remaining) =>
       switch (run(p2, remaining)) {
       | Failure(msg) => Failure(msg)
-      | Success(v2, remaining2) => Success((v1, v2), remaining2)
+      | Success(val2, remaining2) => Success((val1, val2), remaining2)
       }
     };
   Parser(fn);
@@ -51,9 +51,9 @@ let orElse = (p1, p2) => {
   Parser(fn);
 };
 
-let reduce = (f, ls) => List.fold_left(f, List.hd(ls), List.tl(ls));
+let _reduce = (f, ls) => List.fold_left(f, List.hd(ls), List.tl(ls));
 
-let choice = parsers => parsers |> reduce(orElse);
+let choice = parsers => parsers |> _reduce(orElse);
 
 let mapP = (f, parser) => {
   let fn = input => {
@@ -75,13 +75,13 @@ let (|>>) = (x, f) => mapP(f, x);
 let anyOf = chars => chars |> List.map(pchar) |> choice;
 
 let pdigit = {
-  let rec range = (start, end_) =>
-    if (start >= end_) {
+  let rec _range = (start, _end) =>
+    if (start >= _end) {
       [];
     } else {
-      [start, ...range(start + 1, end_)];
+      [start, ..._range(start + 1, _end)];
     };
-  let digits = range(0, 9);
+  let digits = _range(0, 9);
   let ascii0 = 48;
   digits |> List.map(x => x + ascii0) |> List.map(char_of_int) |> anyOf;
 };

--- a/test/ParserTest.re
+++ b/test/ParserTest.re
@@ -3,16 +3,15 @@ open Treason.Parser;
 
 open SuccessExtensions;
 
-type customMatchers('a) = {
-  success:
-    result('a) => successExtensions('a),
+type customMatchers = {
+  success: 'a. result('a) => successExtensions('a),
 };
 
 let customMatchers = createMatcher => {
-  success: actual => successExtensions(actual, createMatcher)
+  success: actual => successExtensions(actual, createMatcher),
 };
 
-let { describe } = extendDescribe(customMatchers);
+let {describe} = extendDescribe(customMatchers);
 
 describe("Parser -> Parsers -> pchar", ({test}) => {
   let pA = pchar('A');
@@ -22,116 +21,114 @@ describe("Parser -> Parsers -> pchar", ({test}) => {
 
     let received = run(pA, input);
 
-    expect.ext.success(received).not.toFail();
+    expect.ext.success(received).toSucceed();
+  });
+
+  test("pchar failure", ({expect}) => {
+    let input = "BC";
+
+    let received = run(pA, input);
+
+    expect.ext.success(received).toFail();
   });
 });
 
-/*   test("pchar failure", ({expect}) => { */
-/*     let input = "BC"; */
+describe("Parser -> Parsers -> pdigit", ({test}) => {
+  test("pdigit sucess", ({expect}) => {
+    let input = "0123";
 
-/*     let received = run(pA, input); */
+    let received = run(pdigit, input);
+    let expected = Success('0', "123");
 
-/*     expect.result(received).toBeError(); */
-/*   }); */
-/* }); */
+    expect.ext.success(received).toBe(expected);
+  });
 
-/* describe("Parser -> Parsers -> pdigit", ({test}) => { */
-/*   test("pchar sucess", ({expect}) => { */
-/*     let input = "0123"; */
+  test("pdigit failure", ({expect}) => {
+    let input = "BC";
 
-/*     let received = run(pdigit, input); */
-/*     let expected = Ok(('0', "123")); */
+    let received = run(pdigit, input);
 
-/*     expect.result(received).toBe(expected); */
-/*   }); */
+    expect.ext.success(received).toFail();
+  });
+});
 
-/*   test("pchar failure", ({expect}) => { */
-/*     let input = "BC"; */
+describe("Parser -> Combinators -> andThen", ({test}) => {
+  let pA = pchar('A');
+  let pB = pchar('B');
+  let pAB = pA @>>@ pB;
 
-/*     let received = run(pdigit, input); */
+  test("andThen success", ({expect}) => {
+    let received = run(pAB, "AB");
+    let expected = Success(('A', 'B'), "");
 
-/*     expect.result(received).toBeError(); */
-/*   }); */
-/* }); */
+    expect.ext.success(received).toBe(expected);
+  });
 
-/* describe("Parser -> Combinators -> andThen", ({test}) => { */
-/*   let pA = pchar('A'); */
-/*   let pB = pchar('B'); */
-/*   let p = pA @>>@ pB; */
+  test("andThen failure 1", ({expect}) => {
+    let received = run(pAB, "BB");
+    expect.ext.success(received).toFail();
+  });
 
-/*   test("andThen success", ({expect}) => { */
-/*     let received = run(p, "AB"); */
-/*     let expected = Ok((('A', 'B'), "")); */
+  test("andThen failure 2", ({expect}) => {
+    let received = run(pAB, "AC");
+    expect.ext.success(received).toFail();
+  });
+});
 
-/*     expect.result(received).toBe(expected); */
-/*   }); */
+describe("Parser -> Combinators -> orElse", ({test}) => {
+  let pA = pchar('A');
+  let pB = pchar('B');
+  let p = pA <|> pB;
 
-/*   test("andThen failure 1", ({expect}) => { */
-/*     let received = run(p, "BB"); */
-/*     expect.result(received).toBeError(); */
-/*   }); */
+  test("orElse success 1", ({expect}) => {
+    let received = run(p, "AC");
+    let expected = Success('A', "C");
 
-/*   test("andThen failure 2", ({expect}) => { */
-/*     let received = run(p, "AC"); */
+    expect.ext.success(received).toBe(expected);
+  });
 
-/*     expect.result(received).toBeError(); */
-/*   }); */
-/* }); */
+  test("orElse success 2", ({expect}) => {
+    let received = run(p, "BC");
+    let expected = Success('B', "C");
 
-/* describe("Parser -> Combinators -> orElse", ({test}) => { */
-/*   let pA = pchar('A'); */
-/*   let pB = pchar('B'); */
-/*   let p = pA <|> pB; */
+    expect.ext.success(received).toBe(expected);
+  });
 
-/*   test("orElse success 1", ({expect}) => { */
-/*     let received = run(p, "AC"); */
-/*     let expected = Ok(('A', "C")); */
+  test("orElse failure", ({expect}) => {
+    let x = run(p, "DC");
 
-/*     expect.result(received).toBe(expected); */
-/*   }); */
+    expect.ext.success(x).toFail();
+  });
+});
 
-/*   test("orElse success 2", ({expect}) => { */
-/*     let received = run(p, "BC"); */
-/*     let expected = Ok(('B', "C")); */
+describe("Parser -> Combinators -> anyOf", ({test}) => {
+  let chars = ['A', 'B', 'C'];
+  let p = anyOf(chars);
 
-/*     expect.result(received).toBe(expected); */
-/*   }); */
+  test("anyOf success 1", ({expect}) => {
+    let received = run(p, "AD");
+    let expected = Success('A', "D");
 
-/*   test("orElse failure", ({expect}) => { */
-/*     let x = run(p, "DC"); */
+    expect.ext.success(received).toBe(expected);
+  });
 
-/*     expect.result(x).toBeError(); */
-/*   }); */
-/* }); */
+  test("anyOf success 2", ({expect}) => {
+    let received = run(p, "BD");
+    let expected = Success('B', "D");
 
-/* describe("Parser -> Combinators -> anyOf", ({test}) => { */
-/*   let chars = ['A', 'B', 'C']; */
-/*   let p = anyOf(chars); */
+    expect.ext.success(received).toBe(expected);
+  });
 
-/*   test("anyOf success 1", ({expect}) => { */
-/*     let received = run(p, "AD"); */
-/*     let expected = Ok(('A', "D")); */
+  test("anyOf success 3", ({expect}) => {
+    let received = run(p, "CD");
+    let expected = Success('C', "D");
 
-/*     expect.result(received).toBe(expected); */
-/*   }); */
+    expect.ext.success(received).toBe(expected);
+  });
 
-/*   test("anyOf success 2", ({expect}) => { */
-/*     let received = run(p, "BD"); */
-/*     let expected = Ok(('B', "D")); */
+  test("anyOf failure 1", ({expect}) => {
+    let received = run(p, "DC");
 
-/*     expect.result(received).toBe(expected); */
-/*   }); */
-
-/*   test("anyOf success 3", ({expect}) => { */
-/*     let received = run(p, "CD"); */
-/*     let expected = Ok(('C', "D")); */
-
-/*     expect.result(received).toBe(expected); */
-/*   }); */
-
-/*   test("anyOf failure 1", ({expect}) => { */
-/*     let received = run(p, "DC"); */
-
-/*     expect.result(received).toBeError(); */
-/*   }); */
-/* }); */
+    expect.ext.success(received).toFail();
+  });
+});

--- a/test/ParserTest.re
+++ b/test/ParserTest.re
@@ -1,6 +1,19 @@
 open TestFramework;
 open Treason.Parser;
 
+open SuccessExtensions;
+
+type customMatchers('a) = {
+  success:
+    result('a) => successExtensions('a),
+};
+
+let customMatchers = createMatcher => {
+  success: actual => successExtensions(actual, createMatcher)
+};
+
+let { describe } = extendDescribe(customMatchers);
+
 describe("Parser -> Parsers -> pchar", ({test}) => {
   let pA = pchar('A');
 
@@ -9,115 +22,116 @@ describe("Parser -> Parsers -> pchar", ({test}) => {
 
     let received = run(pA, input);
 
-    expect.result(received).toBe(Ok(('A', "BC")));
-  });
-
-  test("pchar failure", ({expect}) => {
-    let input = "BC";
-
-    let received = run(pA, input);
-
-    expect.result(received).toBeError();
+    expect.ext.success(received).not.toFail();
   });
 });
 
-describe("Parser -> Parsers -> pdigit", ({test}) => {
-  test("pchar sucess", ({expect}) => {
-    let input = "0123";
+/*   test("pchar failure", ({expect}) => { */
+/*     let input = "BC"; */
 
-    let received = run(pdigit, input);
-    let expected = Ok(('0', "123"));
+/*     let received = run(pA, input); */
 
-    expect.result(received).toBe(expected);
-  });
+/*     expect.result(received).toBeError(); */
+/*   }); */
+/* }); */
 
-  test("pchar failure", ({expect}) => {
-    let input = "BC";
+/* describe("Parser -> Parsers -> pdigit", ({test}) => { */
+/*   test("pchar sucess", ({expect}) => { */
+/*     let input = "0123"; */
 
-    let received = run(pdigit, input);
+/*     let received = run(pdigit, input); */
+/*     let expected = Ok(('0', "123")); */
 
-    expect.result(received).toBeError();
-  });
-});
+/*     expect.result(received).toBe(expected); */
+/*   }); */
 
-describe("Parser -> Combinators -> andThen", ({test}) => {
-  let pA = pchar('A');
-  let pB = pchar('B');
-  let p = pA @>>@ pB;
+/*   test("pchar failure", ({expect}) => { */
+/*     let input = "BC"; */
 
-  test("andThen success", ({expect}) => {
-    let received = run(p, "AB");
-    let expected = Ok((('A', 'B'), ""));
+/*     let received = run(pdigit, input); */
 
-    expect.result(received).toBe(expected);
-  });
+/*     expect.result(received).toBeError(); */
+/*   }); */
+/* }); */
 
-  test("andThen failure 1", ({expect}) => {
-    let received = run(p, "BB");
-    expect.result(received).toBeError();
-  });
+/* describe("Parser -> Combinators -> andThen", ({test}) => { */
+/*   let pA = pchar('A'); */
+/*   let pB = pchar('B'); */
+/*   let p = pA @>>@ pB; */
 
-  test("andThen failure 2", ({expect}) => {
-    let received = run(p, "AC");
+/*   test("andThen success", ({expect}) => { */
+/*     let received = run(p, "AB"); */
+/*     let expected = Ok((('A', 'B'), "")); */
 
-    expect.result(received).toBeError();
-  });
-});
+/*     expect.result(received).toBe(expected); */
+/*   }); */
 
-describe("Parser -> Combinators -> orElse", ({test}) => {
-  let pA = pchar('A');
-  let pB = pchar('B');
-  let p = pA <|> pB;
+/*   test("andThen failure 1", ({expect}) => { */
+/*     let received = run(p, "BB"); */
+/*     expect.result(received).toBeError(); */
+/*   }); */
 
-  test("orElse success 1", ({expect}) => {
-    let received = run(p, "AC");
-    let expected = Ok(('A', "C"));
+/*   test("andThen failure 2", ({expect}) => { */
+/*     let received = run(p, "AC"); */
 
-    expect.result(received).toBe(expected);
-  });
+/*     expect.result(received).toBeError(); */
+/*   }); */
+/* }); */
 
-  test("orElse success 2", ({expect}) => {
-    let received = run(p, "BC");
-    let expected = Ok(('B', "C"));
+/* describe("Parser -> Combinators -> orElse", ({test}) => { */
+/*   let pA = pchar('A'); */
+/*   let pB = pchar('B'); */
+/*   let p = pA <|> pB; */
 
-    expect.result(received).toBe(expected);
-  });
+/*   test("orElse success 1", ({expect}) => { */
+/*     let received = run(p, "AC"); */
+/*     let expected = Ok(('A', "C")); */
 
-  test("orElse failure", ({expect}) => {
-    let x = run(p, "DC");
+/*     expect.result(received).toBe(expected); */
+/*   }); */
 
-    expect.result(x).toBeError();
-  });
-});
+/*   test("orElse success 2", ({expect}) => { */
+/*     let received = run(p, "BC"); */
+/*     let expected = Ok(('B', "C")); */
 
-describe("Parser -> Combinators -> anyOf", ({test}) => {
-  let chars = ['A', 'B', 'C'];
-  let p = anyOf(chars);
+/*     expect.result(received).toBe(expected); */
+/*   }); */
 
-  test("anyOf success 1", ({expect}) => {
-    let received = run(p, "AD");
-    let expected = Ok(('A', "D"));
+/*   test("orElse failure", ({expect}) => { */
+/*     let x = run(p, "DC"); */
 
-    expect.result(received).toBe(expected);
-  });
+/*     expect.result(x).toBeError(); */
+/*   }); */
+/* }); */
 
-  test("anyOf success 2", ({expect}) => {
-    let received = run(p, "BD");
-    let expected = Ok(('B', "D"));
+/* describe("Parser -> Combinators -> anyOf", ({test}) => { */
+/*   let chars = ['A', 'B', 'C']; */
+/*   let p = anyOf(chars); */
 
-    expect.result(received).toBe(expected);
-  });
+/*   test("anyOf success 1", ({expect}) => { */
+/*     let received = run(p, "AD"); */
+/*     let expected = Ok(('A', "D")); */
 
-  test("anyOf success 3", ({expect}) => {
-    let received = run(p, "CD");
-    let expected = Ok(('C', "D"));
+/*     expect.result(received).toBe(expected); */
+/*   }); */
 
-    expect.result(received).toBe(expected);
-  });
+/*   test("anyOf success 2", ({expect}) => { */
+/*     let received = run(p, "BD"); */
+/*     let expected = Ok(('B', "D")); */
 
-  test("anyOf failure 1", ({expect}) => {
-    let received = run(p, "DC");
+/*     expect.result(received).toBe(expected); */
+/*   }); */
 
-    expect.result(received).toBeError();
-  });
-});
+/*   test("anyOf success 3", ({expect}) => { */
+/*     let received = run(p, "CD"); */
+/*     let expected = Ok(('C', "D")); */
+
+/*     expect.result(received).toBe(expected); */
+/*   }); */
+
+/*   test("anyOf failure 1", ({expect}) => { */
+/*     let received = run(p, "DC"); */
+
+/*     expect.result(received).toBeError(); */
+/*   }); */
+/* }); */

--- a/test/SuccessExtensions.re
+++ b/test/SuccessExtensions.re
@@ -1,5 +1,5 @@
-open Treason__Parser;
-open RelyInternal__RelyAPI.MatcherTypes;
+open Treason.Parser;
+open RelyInternal.RelyAPI.MatcherTypes;
 
 type toBe('a) = result('a) => unit;
 

--- a/test/SuccessExtensions.re
+++ b/test/SuccessExtensions.re
@@ -1,0 +1,77 @@
+open Treason__Parser;
+open RelyInternal__RelyAPI.MatcherTypes;
+
+type successExtensionsWithoutNot('a) = {
+  toFail: unit => unit,
+  /* toSucceed: unit => unit, */
+  /* toBe: (result('a)) => unit, */
+};
+
+type successExtensions('a) = {
+  not: successExtensionsWithoutNot('a),
+  toFail: unit => unit,
+  /* toSucceed: unit => unit, */
+  /* toBe: (result('a)) => unit, */
+};
+
+let printResult = res =>
+  switch (res) {
+  | Success(parsed, remaining) =>
+    Printf.sprintf("Success(%c, %s)", parsed, remaining)
+  | Failure(msg) => Printf.sprintf("Failure(%s)", msg)
+  };
+
+let isSuccess = res =>
+  switch (res) {
+  | Success(_) => true
+  | Failure(_) => false
+  };
+
+let isFailure = res => !isSuccess(res);
+
+let successExtensions = (actual, {createMatcher}) => {
+
+  let toFail = isNot =>
+    createMatcher(({formatReceived}, actualThunk, expectedThunk) => {
+      let actual = actualThunk();
+      let actualIsFailure = isFailure(actual);
+
+      switch (actualIsFailure, isNot) {
+      | (true, false)
+      | (false, true) => ((() => ""), true)
+      | (false, false) =>
+        let message =
+          String.concat(
+            "",
+            [
+              "\n\n",
+              "Expected value to be Failure, but received: ",
+              formatReceived(printResult(actual)),
+            ],
+          );
+        ((() => message), false);
+      | (true, true) =>
+        let message =
+          String.concat(
+            "",
+            [
+              "\n\n",
+              "Expected value to not be Failure, but received: ",
+              formatReceived(printResult(actual)),
+            ],
+          );
+        ((() => message), false);
+      };
+    });
+
+  let makeSuccessMatchers = isNot => {
+    toFail: () => toFail(isNot, () => actual, () => ()),
+  };
+
+  let successMatchers = makeSuccessMatchers(false);
+
+  {
+    toFail: successMatchers.toFail,
+    not: makeSuccessMatchers(true),
+  };
+};


### PR DESCRIPTION
Standard OCaml `result('a, 'b) = Ok('a) | Error('b)` is a little awkward since 'a has to be a tuple or record if we want to carry both the parsed and remaining content.

- [x] Add a custom type for results with success holding both the parsed content and the remaining input.
- [x] Add a custom Rely matcher for nice assertions, similar to the existing result matchers.